### PR TITLE
Added check for missing annotation if file exists

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library identifier: 'vapor@1.0.3', retriever: modernSCM([
+library identifier: 'vapor@1.21.22', retriever: modernSCM([
   $class: 'GitSCMSource',
   remote: 'https://github.com/vapor-ware/ci-shared.git',
   credentialsId: 'vio-bot-gh',
@@ -9,4 +9,5 @@ library identifier: 'vapor@1.0.3', retriever: modernSCM([
 dockerBuildPipeline([
   'image': 'vaporio/gcp-gs-downloader',
   'mainBranch': 'stable',
+  "skipClair": true,
 ])

--- a/start.sh
+++ b/start.sh
@@ -16,6 +16,7 @@ printUsage () {
 	echo "This script expects ENV vars SRC to be provided"
 	echo "Alternatively: if in kubernetes, use the downward API to provide ANNOTATIONS"
 	echo "at /etc/podinfo/annotations. It will parse for gs/src"
+	echo "if the annotation is not provided, it will fetch the latest asset from gs"
 }
 
 # The integration point from Kubernetes expects a path in
@@ -32,7 +33,8 @@ printUsage () {
 
 parseAnnotations() {
 	# if the file does not exist, presume local runtime or non-k8s tooling
-	if [ ! -f "${ANNOTATION_FILE}" ];
+	# or if the file exists but the annotation is missing, fallback to the latest mbtile
+	if [ ! -f "${ANNOTATION_FILE}" ] || [ $(cat ${ANNOTATION_FILE} | grep -c ${ANNOTATION_SOURCE}) -eq 0 ];
 	then
 		gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
 		files=$(gsutil ls -r "gs://${BUCKET_NAME}/*/*.mbtiles")


### PR DESCRIPTION
Tileserver deployments in dev and nightly have been failing lately as the gs downloader cannot parse the source path in the event the annotations file exists but the source annotation (`gs/src`) is not present in the file. This change adds this missing check and provides a default source value if the source annotation is not present.

[VIO-3379](https://vaporio.atlassian.net/browse/VIO-3379)

[VIO-3379]: https://vaporio.atlassian.net/browse/VIO-3379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ