### PR TITLE
Added fix for sorting

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -38,7 +38,8 @@ parseAnnotations() {
 	then
 		gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
 		files=$(gsutil ls -r "gs://${BUCKET_NAME}/*/*.mbtiles")
-		myarray=($files)
+		IFS=$'\n' myarray=($files)
+		unset IFS
 		IFS=$'\n' sorted=($(sort -r <<<"${myarray[*]}"))
 		unset IFS
 


### PR DESCRIPTION
Previously the sort logic presumed that there could not be any whitespaces in the source path values. So when they did contain whitespaces it broke sorting and resulted in incorrect path value being returned.

Let's say `files` is a string of source path values
```
gs://vio-mbtiles/20220622T140023891877/fiber.mbtiles
gs://vio-mbtiles/20220623T071921520518/{value:‘fiber’, label:‘fiber’} .mbtiles
```
Directly creating an array from the string using `myarray=($files)` we get the following array
```
gs://vio-mbtiles/20220622T140023891877/fiber.mbtiles
gs://vio-mbtiles/20220623T071921520518/{value:‘fiber’,
label:‘fiber’}
.mbtiles
```
Notice how the initial `files` string is split using whitespaces and resulted `myarray` having four elements instead of just two?
By adding `IFS=$'\n'` before assignment of `myarray` we make sure that the strings are delimited by just new line instead of general whitespace (spaces, tabs, new lines).